### PR TITLE
build(vite): chunks and entrifiles are in `chunks/` folder and assets are in `assets/` folder

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -25,6 +25,6 @@ jobs:
         run: npm run build
 
       - name: Run Gravity
-        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+"
+        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks "chunks/.+\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}

--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -28,3 +28,4 @@ jobs:
         run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks "chunks/.+\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
+          GRAVITY_HOST: ${{ vars.GRAVITY_HOST }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, splitVendorChunkPlugin } from "vite";
+import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import arraybuffer from "vite-plugin-arraybuffer";
@@ -6,15 +6,17 @@ import arraybuffer from "vite-plugin-arraybuffer";
 export default defineConfig({
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        chunkFileNames: () => {
+          return "chunks/[name]-[hash].js";
+        },
+      },
+    },
   },
   ssr: {
     noExternal: ["@docsearch/react"],
   },
   optimizeDeps: { exclude: ["svg2img"] },
-  plugins: [
-    tsconfigPaths(),
-    splitVendorChunkPlugin(),
-    arraybuffer(),
-    reactRouter(),
-  ],
+  plugins: [tsconfigPaths(), arraybuffer(), reactRouter()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
         chunkFileNames: () => {
           return "chunks/[name]-[hash].js";
         },
+        entryFileNames() {
+          return "chunks/[name]-[hash].js";
+        },
       },
     },
   },


### PR DESCRIPTION
This is an example of a Remix Project (vite) where chunks are placed under the `chunks/` folder and assets (CSS, images...) are placed under the `assets/` folder:

### 🔗 [Build comparison link](https://gravity.ci/6598aa20-80a5-4b12-9d87-d74f3f0ad750/projects/ed7f1c53-654b-4b86-b285-a828746b9416/checks/ab33198a-6736-4970-8870-bbf4c224d7b2)

### assets
![CleanShot 2025-04-14 at 18 14 18](https://github.com/user-attachments/assets/27485b8a-d519-434c-97f5-7c010ba9c92e)

### chunks and entryfiles
![CleanShot 2025-04-14 at 18 14 50](https://github.com/user-attachments/assets/7691e8a9-d4a4-4d5c-87b4-da94e52011db)
