### PR TITLE
ci(gravity): chunks, entrifiles and assets are in `assets/` folder

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -25,6 +25,6 @@ jobs:
         run: npm run build
 
       - name: Run Gravity
-        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+"
+        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks "assets/.+\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}

--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -28,3 +28,4 @@ jobs:
         run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks "assets/.+\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
+          GRAVITY_HOST: ${{ vars.GRAVITY_HOST }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,16 @@ import arraybuffer from "vite-plugin-arraybuffer";
 export default defineConfig({
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        chunkFileNames: () => {
+          return "assets/[name]-[hash].js";
+        },
+        entryFileNames() {
+          return "assets/[name]-[hash].js";
+        },
+      },
+    },
   },
   ssr: {
     noExternal: ["@docsearch/react"],


### PR DESCRIPTION
This is an example of a Remix Project (vite) where chunks and entryfiles are placed under the `assets/` folder and assets (CSS, images...) are placed under the `assets/` folder too:

### 🔗 [Build comparison link](https://gravity.ci/6598aa20-80a5-4b12-9d87-d74f3f0ad750/projects/ed7f1c53-654b-4b86-b285-a828746b9416/checks/1547d6e5-7da6-4293-9f38-3f4c2d02970e)

### assets, entryfiles and chunks
![CleanShot 2025-04-14 at 18 25 53](https://github.com/user-attachments/assets/3dcaf09e-98cd-4834-b67c-17d88fce0c1d)
