### PR TITLE
ci(gravity): each chunk and entryfile is placed in their own folder and assets are in `assets/` folder

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -25,6 +25,6 @@ jobs:
         run: npm run build
 
       - name: Run Gravity
-        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+"
+        run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks ".+/(chunk|entry)\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}

--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -28,3 +28,4 @@ jobs:
         run: npx @gravityci/cli "build/**/*" --fingerprint "^.+(\-[0-9A-Za-z_\-]{8})\..+" --js-chunks ".+/(chunk|entry)\.js"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
+          GRAVITY_HOST: ${{ vars.GRAVITY_HOST }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,16 @@ import arraybuffer from "vite-plugin-arraybuffer";
 export default defineConfig({
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        chunkFileNames: () => {
+          return "[name]-[hash]/chunk.js";
+        },
+        entryFileNames() {
+          return "[name]-[hash]/entry.js";
+        },
+      },
+    },
   },
   ssr: {
     noExternal: ["@docsearch/react"],


### PR DESCRIPTION
This is an example of a Remix Project (vite) where chunks and _entryfiles_ are placed under their folder `[name]-[hash]/entry.js` folder, _chunks_ are placed under their own folder `[name]-[hash]/chunk.js` and assets (CSS, images...) are placed under the `assets/` folder:

### 🔗 [Build comparison link](https://gravity.ci/6598aa20-80a5-4b12-9d87-d74f3f0ad750/projects/ed7f1c53-654b-4b86-b285-a828746b9416/checks/e29d7177-6d3d-48c5-bd2c-cf1593888d66)

### entryfiles
![CleanShot 2025-04-14 at 18 34 18](https://github.com/user-attachments/assets/e1599eac-9e1a-456e-87e4-096042e4381e)

### chunks
![CleanShot 2025-04-14 at 18 34 55](https://github.com/user-attachments/assets/008bb165-c50f-4ebd-aa2e-167849920ba7)

### assets
![CleanShot 2025-04-14 at 18 34 34](https://github.com/user-attachments/assets/1de1dade-ad73-4529-ba98-78fa0d727a96)